### PR TITLE
RFC: Project naming guidelines

### DIFF
--- a/processes/Project Naming.md
+++ b/processes/Project Naming.md
@@ -1,0 +1,69 @@
+# Project Naming Guidelines
+
+The names of projects can have meaning and send messages, intentionally or not.
+To avoid sending the wrong messages, this document includes a few *non-binding*
+recommendations for project naming.
+
+These guidelines apply primarily to early sandbox projects.
+It is expected that as a project reaches maturity and adoption, the OMF will re-evaluate
+its name before folding its maintenance into the organization.
+
+## 1. Avoid tentpole names
+
+Having a large amount of projects and standard proposals share the same or similar names,
+can create the impression that the Open Metaverse Foundation is attempting to create a
+'name brand' standard.
+This gives the impression to other groups that it is forcing a specific vision through on
+name and momentum alone, and locking other groups out of the conversation.
+This is directly in conflict with our core goals and vision, which encourage working with
+other groups.
+
+Additionally, not all projects will adopted and continue to be maintained by the OMF.
+Avoiding tentpole names allows these projects to be branched out and continued by other
+groups, without creating additional confusion.
+
+### Avoid names that directly associate with the Open Metaverse Foundation
+
+The following names are examples of what you should **not** do:
+
+- OMF Object
+- OpenMV Viewer
+
+Folding individual projects under the OMF tentpole by name creates unnecessary conflict.
+
+### Avoid names that directly associate with other projects
+
+The following names are examples of what you should **not** do:
+
+- Linux Metaverse
+- OpenXR Viewer
+
+This appears like the OMF is trying to claim ownership over other groups.
+
+### Avoid common names for multiple projects
+
+The following names, while fine on their own, are examples of what you should **not** do
+in aggregate:
+
+- Menos Viewer
+- Menos Object Format
+- Standard Menos API
+
+Example name "Menos" taken from the greek word "berdeménos" to mean "confusing".
+
+While a project name "Menos Viewer" by itself would be fine, multiple separate projects
+all following the same 'tentpole' name, again creates a 'name brand' association we
+want to avoid.
+
+## 2. Avoid name conflicts
+
+Before picking a name for a project, make sure that your name doesn't conflict with other
+active open source projects.
+This will avoid creating unnecessary conflict.
+
+## 3. Discuss project names with the community
+
+Discussing names with the OMF community before using them will allow issues to be spotted
+early that you may have missed.
+For example, certain words have different (and sometimes offensive) meanings in other
+languages.


### PR DESCRIPTION
Recently, I created a sandbox project named ["omfobj-viewer-proto"](https://github.com/open-mv-sandbox/omfobj-viewer-proto). I had picked this name with the intent of being a placeholder name to be later changed, but it was pointed out to me that the name can cause unnecessary conflict with other groups.

As I'm in the process of figuring out a new name for this, I wanted to write out some potential naming recommendations, to avoid this issue in the future.